### PR TITLE
[fix] asks to install `acpi` even when it is installed

### DIFF
--- a/battery-notification.sh
+++ b/battery-notification.sh
@@ -16,7 +16,7 @@
 eval "export $(egrep -z DBUS_SESSION_BUS_ADDRESS /proc/$(pgrep -u $LOGNAME gnome-session)/environ)";
 
 # check if acpi and send-notify are installed.
-if [ `dpkg -l | grep acpi | grep -v acpi-support | grep -v acpid | grep -c acpi` -ne 1 ]; then
+if [ `dpkg -l | grep acpi | grep -v acpi-support | grep -v acpid | grep -c acpi` -le 1 ]; then
 	echo "run 'sudo apt install acpi' then run '$0' again."
 	exit
 fi


### PR DESCRIPTION
On line, `if [ `dpkg -l | grep acpi | grep -v acpi-support | grep -v acpid | grep -c acpi` -ne 1 ]; then`, the comparison is made with the count to assess if the user has `acpi` installed on the system or not. 

However, a catch here is that we are comparing it for inequality with 1 which may happen if the count is more than 1 as well, and hence is such a case a false error is generated.

This PR fixes the aforementioned issue by using `le`, i.e. less than, comparison with 1 and hence produces better output and shows no error if the match is more than 0.